### PR TITLE
DO-1741: matrix Python versions (3.11/3.12/3.14) on Rocky base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
 ARG ROCKY_VERSION=9
 FROM rockylinux:${ROCKY_VERSION}-minimal
 
+# Python minor version. Must match a Rocky AppStream packaged stream (e.g. 3.11, 3.12, 3.14).
+ARG PYTHON_VERSION=3.12
+
 RUN microdnf --nodocs -y upgrade && \
     microdnf --nodocs -y install \
-    python3 \
-    python3-pip && \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-pip && \
     microdnf --nodocs -y reinstall tzdata && \
+    ln -sf /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python3 && \
+    ln -sf /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python && \
+    ln -sf /usr/bin/pip${PYTHON_VERSION} /usr/local/bin/pip3 && \
+    ln -sf /usr/bin/pip${PYTHON_VERSION} /usr/local/bin/pip && \
     microdnf clean all

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # docker-python
 
-This repository provides Fedora-based Python Docker images.
+Rocky Linux-based Python base images, rebuilt weekly with OS security updates.
+
+## Tags
+
+Built per Python minor version (Rocky 9 AppStream `python<X.Y>` streams):
+
+- `acornsaustralia/python:3.11`
+- `acornsaustralia/python:3.12`
+- `acornsaustralia/python:3.14`
+
+Each build is also pinned as `:<version>-<GITHUB_RUN_NUMBER>`. In every image `python3` / `python` / `pip3` / `pip` resolve to that version.
+
+## Adding a version
+
+Add the stream to the `ver` matrix in `docker-bake.hcl` — it must be an available Rocky AppStream `python<X.Y>` package.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -9,16 +9,26 @@ group "default" {
 }
 
 target "python" {
+  name = "python-${replace(ver, ".", "-")}"
+  matrix = {
+    ver = [
+      "3.11",
+      "3.12",
+      "3.14"
+    ]
+  }
+
   pull = true
   tags = [
-    "acornsaustralia/python:latest",
-    GITHUB_RUN_NUMBER != null ? "acornsaustralia/python:${GITHUB_RUN_NUMBER}" : ""
+    "acornsaustralia/python:${ver}",
+    GITHUB_RUN_NUMBER != null ? "acornsaustralia/python:${ver}-${GITHUB_RUN_NUMBER}" : ""
   ]
   platforms = [
     "linux/amd64",
     "linux/arm64"
   ]
   args = {
-    "ROCKY_VERSION" = "9"
+    "ROCKY_VERSION"  = "9"
+    "PYTHON_VERSION" = ver
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,4 +2,6 @@ services:
   python:
     build:
       context: .
-    image: acornsaustralia/python:latest
+      args:
+        PYTHON_VERSION: "3.12"
+    image: acornsaustralia/python:3.12


### PR DESCRIPTION
## What
- Build `base/python` as a **matrix of Python minor versions** on the Rocky base instead of a single Rocky 9 system-Python (3.9) image.
- Tags produced: `acornsaustralia/python:3.11`, `:3.12`, `:3.14` (+ `:<ver>-<GITHUB_RUN_NUMBER>` pins).
- `Dockerfile`: `PYTHON_VERSION` arg installs the versioned `python<X.Y>` + `-pip` stream; `python`/`python3`/`pip`/`pip3` symlinked to it.
- `docker-bake.hcl`: `ver` matrix. `docker-compose.yml`: local build defaults to 3.12. README updated (also corrected "Fedora" → Rocky).

## Why
- Python services needing newer than 3.9 (e.g. dwh-etl, `requires-python >=3.13`) currently fall back to upstream Debian `python:*-slim`, which carries recurring OS CVEs (perl chain, glibc/openssl churn) and isn't on the weekly-patched Rocky base.
- Rocky 9 AppStream ships `python3.11 / 3.12 / 3.14`; the Rocky base scans 0 HIGH/CRITICAL. (No 3.13 stream — 3.14 covers `>=3.13`.)

## Verified
- `docker buildx bake --print` resolves 3 targets × 2 platforms with correct tags/args.
- Test build of 3.14: `python`/`python3`/`pip` → 3.14.5 on Rocky 9.8.

Ticket: DO-1741. Follow-up: migrate Python services (dwh-etl first) onto these tags after app-compat testing.
